### PR TITLE
Default port for HTTP should be avoided

### DIFF
--- a/charts/chainsaw-app-service/values.yaml
+++ b/charts/chainsaw-app-service/values.yaml
@@ -32,7 +32,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 90
 
 ingress:
   enabled: false
@@ -50,12 +50,12 @@ ingress:
 livenessProbe:
   httpGet:
     path: /
-    port: 80
+    port: 90
 
 readinessProbe:
   httpGet:
     path: /
-    port: 80
+    port: 90
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Why
Default ports are susceptible to vulnerabilities

Description
Most cyber attacks occur due to default port usage. Reff: https://www.bleepingcomputer.com/news/security/most-cyber-attacks-focus-on-just-three-tcp-ports/#:~:text=According%20to%20the%20report%2C%20the,(Hypertext%20Transfer%20Protocol%20Secure) 